### PR TITLE
Fix Mirror Staking staker param

### DIFF
--- a/src/contracts/MirrorStaking.ts
+++ b/src/contracts/MirrorStaking.ts
@@ -67,7 +67,7 @@ export namespace MirrorStaking {
 
   export interface QueryRewardInfo {
     reward_info: {
-      staker: AccAddress;
+      staker_addr: AccAddress;
       asset_token?: AccAddress;
     };
   }
@@ -92,7 +92,7 @@ export namespace MirrorStaking {
   }
 
   export interface RewardInfoResponse {
-    staker: AccAddress;
+    staker_addr: AccAddress;
     reward_infos: Array<RewardInfoResponseItem>;
   }
 
@@ -224,12 +224,12 @@ export class MirrorStaking extends ContractClient {
   }
 
   public async getRewardInfo(
-    staker: AccAddress,
+    staker_addr: AccAddress,
     asset_token?: AccAddress
   ): Promise<MirrorStaking.RewardInfoResponse> {
     return this.query({
       reward_info: {
-        staker,
+        staker_addr,
         asset_token
       }
     });


### PR DESCRIPTION
Currently the method `mirror.staking.getRewardInfo(address)` is returning an error `contract query failed: parsing mirror_protocol::staking::QueryMsg: missing field staker_addr`, because according to the [mirror contract for staking](https://github.com/Mirror-Protocol/mirror-contracts/blob/master/contracts/mirror_staking/src/rewards.rs#L213-L217) the correct name for the staker address is `staker_addr`.