### PR TITLE
[bugfix] pass undefined for empty key

### DIFF
--- a/src/utils/EmptyKey.ts
+++ b/src/utils/EmptyKey.ts
@@ -2,7 +2,7 @@ import { Key } from '@terra-money/terra.js';
 
 export class EmptyKey extends Key {
   constructor() {
-    super(Buffer.from(''));
+    super(undefined);
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
close #18 

terra.js executes `addressFromPublicKey` function unless the given key is `undefined`.
https://github.com/terra-money/terra.js/blob/22f6d5726c7381b426d2d786e2cf380ba89fe660/src/key/Key.ts#L105